### PR TITLE
Revert copyrights changes

### DIFF
--- a/CloudFlare/cloudflare.py
+++ b/CloudFlare/cloudflare.py
@@ -5,7 +5,6 @@ A Python interface Cloudflare's v4 API.
 See README.md for detailed/further reading.
 
 Copyright (c) 2016 thru 2024, Cloudflare. All rights reserved.
-Copyright (c) 2024 onward, Stainless Inc. All rights reserved.
 """
 
 import json

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,6 @@ The MIT License (MIT)
 
 Copyright (c) 2016 Felix Wong and contributors
 Copyright (c) 2016 thru 2024, Cloudflare and contributors
-Copyright (c) 2024, Stainless Inc. and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTEST = pytest
 
 SPHINX_RELEASE = 2.20.0
 SPHINX_AUTHOR = Martin J. Levy
-SPHINX_COPYRIGHT = Copyright (c) 2016 thru 2024, Cloudflare. 2024 onward, Stainless Inc. All rights reserved.
+SPHINX_COPYRIGHT = Copyright (c) 2016 thru 2024, Cloudflare. All rights reserved.
 
 EMAIL = "mahtin@mahtin.com"
 NAME = "cloudflare"

--- a/README.md
+++ b/README.md
@@ -995,7 +995,6 @@ As of May 2024, the code has been moved to [Stainless Inc.](https://github.com/s
 
 Based on original work from [Felix Wong (gnowxilef)](https://github.com/gnowxilef) found [here](https://github.com/cloudflare-api/python-cloudflare-v4).
 Maintained until 2024 by [Martin J. Levy (mahtin)](https://github.com/mahtin).
-The ownership has been officially transferred to [Stainless Inc](http://stainlessapi.com) in 2024.
 
 ## Changelog
 
@@ -1004,5 +1003,4 @@ An automatically generated CHANGELOG is provided [here](CHANGELOG.md).
 ## Copyright
 
 Copyright (c) 2016 thru 2024, Cloudflare. All rights reserved.
-Copyright (c) 2024 onward, Stainless Inc. All rights reserved.
 Previous portions copyright [Felix Wong (gnowxilef)](https://github.com/gnowxilef).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'python-cloudflare'
-copyright = 'Copyright (c) 2016 thru 2024, Cloudflare. 2024 onward, Stainless Inc. All rights reserved. '
+copyright = 'Copyright (c) 2016 thru 2024, Cloudflare. All rights reserved. '
 author = 'Martin J Levy'
 
 version = '2.20.0'


### PR DESCRIPTION
After confirmation the Copyrights stays with Cloudflare. Reverting changes from https://github.com/cloudflare/python-cloudflare-cli4/commit/2db7d14ff2f34013e267626525042851fa522299.